### PR TITLE
Changes made to work with orders shipped via V2 API call

### DIFF
--- a/app/code/community/Klarna/CaptureWhenOrderComplete/Model/Observer.php
+++ b/app/code/community/Klarna/CaptureWhenOrderComplete/Model/Observer.php
@@ -1,21 +1,34 @@
 <?php
-
+/**
+ * Class Klarna_CaptureWhenOrderComplete_Model_Observer
+ */
 class Klarna_CaptureWhenOrderComplete_Model_Observer
 {
-    public function salesOrderSaveCommitAfter(Varien_Event_Observer $observer)
+    const LOG_LOCATION = 'klarna_capture.log';
+    /**
+     * @param Varien_Event_Observer $observer
+     */
+    public function captureInvoices(Varien_Event_Observer $observer)
     {
         if (Mage::getStoreConfig('payment/klarna_capturewhenordercomplete/active')) {
-            $order = $observer->getEvent()->getOrder();
+            /** @var Mage_Sales_Model_Order $order */
+            $order = $observer->getEvent()->getShipment()->getOrder();
             if ($this->isKlarnaPayment($order)) {
-                if($order->getState() === Mage_Sales_Model_Order::STATE_COMPLETE) {
-                    $invoices = $order->getInvoiceCollection();
-                    foreach ($invoices as $invoice) {
+                $invoices = $order->getInvoiceCollection();
+                /** @var Mage_Sales_Model_Order_Invoice $invoice */
+                foreach ($invoices as $invoice) {
+                    if ($invoice->getState() == Mage_Sales_Model_Order_Invoice::STATE_OPEN) {
                         try {
-                            $invoice->capture();
-                            $order->addStatusHistoryComment('Invoice ' . $invoice->getIncrementId() . ' captured online.');
+                            $invoice->pay();
+                            $invoice->capture()->save();
+                            $order->addStatusHistoryComment(
+                                "Invoice {$invoice->getIncrementId()} captured online."
+                            )->save();
                         } catch (Mage_Core_Exception $e) {
                             Mage::logException($e);
-                            $order->addStatusHistoryComment('Error whilst capturing invoice ' . $invoice->getIncrementId() . '.');
+                            $order->addStatusHistoryComment(
+                                "Error whilst capturing invoice {$invoice->getIncrementId()}."
+                            )->save();
                         }
                     }
                 }
@@ -24,46 +37,50 @@ class Klarna_CaptureWhenOrderComplete_Model_Observer
     }
 
     /**
-     * @param Mage_Sales_Model_Order $order
-     * @throws Exception
+     * @param Varien_Event_Observer $observer
+     * @return $this
      */
     public function kcoCreateInvoice(Varien_Event_Observer $observer)
     {
         if (Mage::getStoreConfig('payment/klarna_capturewhenordercomplete/active')) {
+            /** @var Mage_Sales_Model_Order $order */
             $order = $observer->getEvent()->getOrder();
             if ($this->isKlarnaPayment($order)) {
                 if ($order->canInvoice()) {
                     try {
+                        /** @var Mage_Sales_Model_Order_Invoice $invoice */
                         $invoice = $order->prepareInvoice();
                         $invoice->setRequestedCaptureCase(Mage_Sales_Model_Order_Invoice::NOT_CAPTURE);
-                        $invoice->register()->pay();
+                        $invoice->setState(Mage_Sales_Model_Order_Invoice::STATE_OPEN);
+                        $invoice->register();
                         Mage::getModel('core/resource_transaction')
                             ->addObject($invoice)
-                            ->addObject($invoice->getOrder())
+                            ->addObject($order)
                             ->save();
-                        $order->addStatusHistoryComment('Invoice ' . $invoice->getIncrementId() . ' created automatically');
+                        $order->addStatusHistoryComment(
+                            "Invoice {$invoice->getIncrementId()} created automatically"
+                        )->save();
                     } catch (Mage_Core_Exception $e) {
                         Mage::logException($e);
-                        $order->addStatusHistoryComment('Error whilst creating an invoice automatically');
+                        $order->addStatusHistoryComment('Error whilst creating an invoice automatically')->save();
                     }
-                } else {
-                    Mage::log('Klarna order ' . $order->getIncrementId() . ' cannot create invoice');
-                    $order->addStatusHistoryComment('Cannot create invoice automatically');
+
+                    return $this;
                 }
-            $order->save();
+
+                Mage::log("Klarna order {$order->getIncrementId()} cannot create invoice", Zend_Log::ALERT, self::LOG_LOCATION);
+                $order->addStatusHistoryComment('Cannot create invoice automatically')->save();
             }
         }
     }
 
+    /**
+     * @param Mage_Sales_Model_Order $order
+     * @return bool
+     */
     public function isKlarnaPayment($order)
     {
-        $payment = $order->getPayment();
-
-        if ($payment->getMethod() != 'klarna_kco') {
-            return false;
-        }
-
-        return true;
+        return $order->getPayment()->getMethod() == 'klarna_kco';
     }
 
 }

--- a/app/code/community/Klarna/CaptureWhenOrderComplete/etc/config.xml
+++ b/app/code/community/Klarna/CaptureWhenOrderComplete/etc/config.xml
@@ -17,15 +17,15 @@
             </klarna_capturewhenordercomplete>
         </models>
         <events>
-            <sales_order_save_commit_after>
+            <sales_order_shipment_save_before>
                 <observers>
-                    <klarna_capturewhenordercomplete_capture>
+                    <klarna_capture_before_shipment_save>
                         <type>model</type>
                         <class>klarna_capturewhenordercomplete/observer</class>
-                        <method>salesOrderSaveCommitAfter</method>
-                    </klarna_capturewhenordercomplete_capture>
+                        <method>captureInvoices</method>
+                    </klarna_capture_before_shipment_save>
                 </observers>
-            </sales_order_save_commit_after>
+            </sales_order_shipment_save_before>
             <kco_push_notification_after>
                 <observers>
                     <klarna_capturewhenordercomplete_create_invoice>


### PR DESCRIPTION
Creating invoices with the correct open state as they are not paid yet. Changing capture event to shipment save (this may not work with virtual products as they do not require shipments - have not tested this).

Using the Magento admin to create shipments and also using calls to salesOrderShipmentCreate via the V2 Magento API - the invoices are captured and orders are marked as complete correctly.